### PR TITLE
Add PhpdocSimplifyArrayKeyFixer

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(make:*)"
+    ]
+  }
+}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
 
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,6 +40,6 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
 
-      - run: composer update --no-interaction --no-progress --prefer-${{ matrix.dependencies }}
+      - run: composer update --no-interaction --no-progress ${{ matrix.dependencies == 'lowest' && '--prefer-lowest' || '' }}
 
       - run: vendor/bin/phpunit

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,45 @@
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+name: "Validate"
+
+jobs:
+  composer-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+
+      - run: composer validate --strict
+
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - "7.4"
+          - "8.0"
+          - "8.1"
+          - "8.2"
+          - "8.3"
+          - "8.4"
+        dependencies:
+          - lowest
+          - highest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      - run: composer update --no-interaction --no-progress --prefer-${{ matrix.dependencies }}
+
+      - run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
+.build/
 .idea
-vendor
-composer.lock
 .php-cs-fixer.cache
+composer.lock
+vendor

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,13 +1,10 @@
 <?php declare(strict_types=1);
 
-use PhpCsFixer\Finder;
-use function MLL\PhpCsFixerConfig\risky;
-
-$finder = Finder::create()
+$finder = PhpCsFixer\Finder::create()
     ->notPath('vendor')
     ->in(__DIR__)
     ->name('*.php')
     ->ignoreDotFiles(true)
     ->ignoreVCS(true);
 
-return risky($finder);
+return MLL\PhpCsFixerConfig\risky($finder);

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: it
-it: fix normalize ## Perform quality checks
+it: fix normalize test ## Perform quality checks
 
 .PHONY: help
 help: ## Displays this list of targets with descriptions
@@ -15,6 +15,11 @@ fix: ## Format PHP
 .PHONY: normalize
 normalize: ## Normalize composer.json
 	composer normalize
+
+.PHONY: test
+test: ## Run PHPUnit tests
+	mkdir --parent .build/phpunit
+	vendor/bin/phpunit --cache-directory=.build/phpunit
 
 vendor: composer.json ## Install dependencies through composer
 	composer install

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "kubawerlos/php-cs-fixer-custom-fixers": "^3.12"
   },
   "require-dev": {
-    "ergebnis/composer-normalize": "^2.13"
+    "ergebnis/composer-normalize": "^2.13",
+    "phpunit/phpunit": "^9.6 || ^10.5 || ^11.0"
   },
   "autoload": {
     "psr-4": {
@@ -28,6 +29,11 @@
     "files": [
       "config.php"
     ]
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "MLL\\PhpCsFixerConfig\\Tests\\": "tests/"
+    }
   },
   "config": {
     "allow-plugins": {

--- a/config.php
+++ b/config.php
@@ -2,6 +2,7 @@
 
 namespace MLL\PhpCsFixerConfig;
 
+use MLL\PhpCsFixerConfig\Fixer\PhpdocSimplifyArrayKeyFixer;
 use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
 use PhpCsFixerCustomFixers;
@@ -68,6 +69,7 @@ function config(Finder $finder, array $ruleOverrides = []): Config
         ],
         'phpdoc_order' => true,
         'phpdoc_to_comment' => false, // Intermediary PHPDocs are sometimes useful to provide type assertions for PHPStan
+        PhpdocSimplifyArrayKeyFixer::name() => true,
         'single_line_empty_body' => true,
         'single_line_throw' => true,
         // TODO add trailing commas everywhere when dropping PHP 7.4
@@ -94,6 +96,7 @@ function config(Finder $finder, array $ruleOverrides = []): Config
 
     return (new Config())
         ->registerCustomFixers(new PhpCsFixerCustomFixers\Fixers())
+        ->registerCustomFixers([new PhpdocSimplifyArrayKeyFixer()])
         ->setFinder($finder)
         ->setRules(array_merge($safeRules, $ruleOverrides));
 }

--- a/config.php
+++ b/config.php
@@ -2,7 +2,6 @@
 
 namespace MLL\PhpCsFixerConfig;
 
-use MLL\PhpCsFixerConfig\Fixer\PhpdocSimplifyArrayKeyFixer;
 use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
 use PhpCsFixerCustomFixers;
@@ -69,7 +68,6 @@ function config(Finder $finder, array $ruleOverrides = []): Config
         ],
         'phpdoc_order' => true,
         'phpdoc_to_comment' => false, // Intermediary PHPDocs are sometimes useful to provide type assertions for PHPStan
-        PhpdocSimplifyArrayKeyFixer::name() => true,
         'single_line_empty_body' => true,
         'single_line_throw' => true,
         // TODO add trailing commas everywhere when dropping PHP 7.4
@@ -89,6 +87,8 @@ function config(Finder $finder, array $ruleOverrides = []): Config
             'less_and_greater' => false,
         ],
 
+        Fixer\PhpdocSimplifyArrayKeyFixer::NAME => true,
+
         PhpCsFixerCustomFixers\Fixer\ConstructorEmptyBracesFixer::name() => true,
         PhpCsFixerCustomFixers\Fixer\DeclareAfterOpeningTagFixer::name() => true, // Use native rule when added with https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/2062
         PhpCsFixerCustomFixers\Fixer\MultilinePromotedPropertiesFixer::name() => true,
@@ -96,7 +96,9 @@ function config(Finder $finder, array $ruleOverrides = []): Config
 
     return (new Config())
         ->registerCustomFixers(new PhpCsFixerCustomFixers\Fixers())
-        ->registerCustomFixers([new PhpdocSimplifyArrayKeyFixer()])
+        ->registerCustomFixers([
+            new Fixer\PhpdocSimplifyArrayKeyFixer(),
+        ])
         ->setFinder($finder)
         ->setRules(array_merge($safeRules, $ruleOverrides));
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+
+    <testsuites>
+        <testsuite name="Tests">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,12 +5,6 @@
     bootstrap="vendor/autoload.php"
     colors="true"
 >
-    <source>
-        <include>
-            <directory>src</directory>
-        </include>
-    </source>
-
     <testsuites>
         <testsuite name="Tests">
             <directory>tests</directory>

--- a/src/Fixer/PhpdocSimplifyArrayKeyFixer.php
+++ b/src/Fixer/PhpdocSimplifyArrayKeyFixer.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace MLL\PhpCsFixerConfig\Fixer;
+
+use PhpCsFixer\AbstractPhpdocTypesFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Preg;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * Simplifies array<array-key, T> to array<T>.
+ *
+ * Since array-key is equivalent to int|string and arrays naturally have int|string keys,
+ * specifying this explicitly is redundant.
+ */
+final class PhpdocSimplifyArrayKeyFixer extends AbstractPhpdocTypesFixer
+{
+    public function getName(): string
+    {
+        return 'MLL/phpdoc_simplify_array_key';
+    }
+
+    public static function name(): string
+    {
+        return (new self())->getName();
+    }
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'PHPDoc `array<T>` should be used instead of `array<array-key, T>`.',
+            [
+                new CodeSample(
+                    <<<'PHP'
+                        <?php
+                        /**
+                         * @param array<array-key, string> $x
+                         * @return array<int|string, Foo>
+                         */
+
+                        PHP
+                ),
+            ]
+        );
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(T_DOC_COMMENT);
+    }
+
+    protected function normalize(string $type): string
+    {
+        // Match: array<array-key, T> or array<int|string, T> or array<string|int, T>
+        return Preg::replace(
+            '/\barray<\s*(?:array-key|int\s*\|\s*string|string\s*\|\s*int)\s*,\s*/',
+            'array<',
+            $type
+        );
+    }
+}

--- a/tests/Fixer/PhpdocSimplifyArrayKeyFixerTest.php
+++ b/tests/Fixer/PhpdocSimplifyArrayKeyFixerTest.php
@@ -1,0 +1,240 @@
+<?php declare(strict_types=1);
+
+namespace MLL\PhpCsFixerConfig\Tests\Fixer;
+
+use MLL\PhpCsFixerConfig\Fixer\PhpdocSimplifyArrayKeyFixer;
+use PhpCsFixer\Tokenizer\Tokens;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class PhpdocSimplifyArrayKeyFixerTest extends TestCase
+{
+    private PhpdocSimplifyArrayKeyFixer $fixer;
+
+    protected function setUp(): void
+    {
+        $this->fixer = new PhpdocSimplifyArrayKeyFixer();
+    }
+
+    #[DataProvider('provideFixCases')]
+    public function testFix(string $expected, ?string $input = null): void
+    {
+        $input ??= $expected;
+
+        $tokens = Tokens::fromCode($input);
+        $this->fixer->fix(new \SplFileInfo(__FILE__), $tokens);
+        $actual = $tokens->generateCode();
+
+        self::assertSame($expected, $actual);
+
+        // Test idempotency
+        $tokens = Tokens::fromCode($expected);
+        $this->fixer->fix(new \SplFileInfo(__FILE__), $tokens);
+        self::assertSame($expected, $tokens->generateCode());
+    }
+
+    /** @return iterable<string, array{0: string, 1?: string}> */
+    public static function provideFixCases(): iterable
+    {
+        yield 'simplifies array-key to omit key type' => [
+            '<?php
+/**
+ * @param array<string> $x
+ */
+',
+            '<?php
+/**
+ * @param array<array-key, string> $x
+ */
+',
+        ];
+
+        yield 'simplifies int|string to omit key type' => [
+            '<?php
+/**
+ * @return array<Foo>
+ */
+',
+            '<?php
+/**
+ * @return array<int|string, Foo>
+ */
+',
+        ];
+
+        yield 'simplifies string|int to omit key type' => [
+            '<?php
+/**
+ * @param array<Bar> $y
+ */
+',
+            '<?php
+/**
+ * @param array<string|int, Bar> $y
+ */
+',
+        ];
+
+        yield 'handles multiple annotations in one docblock' => [
+            '<?php
+/**
+ * @param array<string> $x
+ * @param array<int> $y
+ * @return array<Foo>
+ */
+',
+            '<?php
+/**
+ * @param array<array-key, string> $x
+ * @param array<array-key, int> $y
+ * @return array<int|string, Foo>
+ */
+',
+        ];
+
+        yield 'handles nested array types' => [
+            '<?php
+/**
+ * @param array<array<string>> $x
+ */
+',
+            '<?php
+/**
+ * @param array<array-key, array<string>> $x
+ */
+',
+        ];
+
+        yield 'handles whitespace variations' => [
+            '<?php
+/**
+ * @param array<string> $x
+ */
+',
+            '<?php
+/**
+ * @param array<  array-key  ,  string> $x
+ */
+',
+        ];
+
+        yield 'leaves already simplified array unchanged' => [
+            '<?php
+/**
+ * @param array<string> $x
+ */
+',
+        ];
+
+        yield 'leaves non-array types unchanged' => [
+            '<?php
+/**
+ * @param string $x
+ * @param int $y
+ */
+',
+        ];
+
+        yield 'leaves specific int key unchanged' => [
+            '<?php
+/**
+ * @param array<int, string> $x
+ */
+',
+        ];
+
+        yield 'leaves specific string key unchanged' => [
+            '<?php
+/**
+ * @param array<string, Foo> $x
+ */
+',
+        ];
+
+        yield 'leaves code without docblock unchanged' => [
+            '<?php
+function foo() {}
+',
+        ];
+
+        yield 'handles @var annotation' => [
+            '<?php
+/** @var array<string> $x */
+',
+            '<?php
+/** @var array<array-key, string> $x */
+',
+        ];
+
+        yield 'handles @property annotation' => [
+            '<?php
+/**
+ * @property array<Foo> $items
+ */
+',
+            '<?php
+/**
+ * @property array<array-key, Foo> $items
+ */
+',
+        ];
+
+        // Note: AbstractPhpdocTypesFixer requires transformations to preserve line count.
+        // Multiline types that would require removing a line cannot be transformed.
+        // This is a known limitation of the php-cs-fixer framework.
+
+        yield 'leaves multiline array-key unchanged (line count would change)' => [
+            '<?php
+/**
+ * @param array<
+ *     array-key,
+ *     string
+ * > $x
+ */
+',
+        ];
+
+        yield 'leaves multiline int|string unchanged (line count would change)' => [
+            '<?php
+/**
+ * @param array<
+ *     int|string,
+ *     Foo
+ * > $items
+ */
+',
+        ];
+
+        yield 'leaves multiline with specific key unchanged' => [
+            '<?php
+/**
+ * @param array<
+ *     int,
+ *     string
+ * > $x
+ */
+',
+        ];
+
+        yield 'simplifies single-line type within multiline docblock' => [
+            '<?php
+/**
+ * A function with a long description
+ * that spans multiple lines.
+ *
+ * @param array<string> $x The input array
+ * @return void
+ */
+',
+            '<?php
+/**
+ * A function with a long description
+ * that spans multiple lines.
+ *
+ * @param array<array-key, string> $x The input array
+ * @return void
+ */
+',
+        ];
+    }
+}

--- a/tests/Fixer/PhpdocSimplifyArrayKeyFixerTest.php
+++ b/tests/Fixer/PhpdocSimplifyArrayKeyFixerTest.php
@@ -4,19 +4,21 @@ namespace MLL\PhpCsFixerConfig\Tests\Fixer;
 
 use MLL\PhpCsFixerConfig\Fixer\PhpdocSimplifyArrayKeyFixer;
 use PhpCsFixer\Tokenizer\Tokens;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class PhpdocSimplifyArrayKeyFixerTest extends TestCase
 {
-    private PhpdocSimplifyArrayKeyFixer $fixer;
+    /** @var PhpdocSimplifyArrayKeyFixer */
+    private $fixer;
 
     protected function setUp(): void
     {
         $this->fixer = new PhpdocSimplifyArrayKeyFixer();
     }
 
-    #[DataProvider('provideFixCases')]
+    /**
+     * @dataProvider provideFixCases
+     */
     public function testFix(string $expected, ?string $input = null): void
     {
         $input ??= $expected;

--- a/tests/Fixer/PhpdocSimplifyArrayKeyFixerTest.php
+++ b/tests/Fixer/PhpdocSimplifyArrayKeyFixerTest.php
@@ -16,9 +16,7 @@ final class PhpdocSimplifyArrayKeyFixerTest extends TestCase
         $this->fixer = new PhpdocSimplifyArrayKeyFixer();
     }
 
-    /**
-     * @dataProvider provideFixCases
-     */
+    /** @dataProvider provideFixCases */
     public function testFix(string $expected, ?string $input = null): void
     {
         $input ??= $expected;


### PR DESCRIPTION
## Summary

Adds a custom fixer that simplifies `array<array-key, T>` to `array<T>`.

Since `array-key` is equivalent to `int|string` and arrays naturally have `int|string` keys, specifying this explicitly is redundant. The fixer also handles `array<int|string, T>` and `array<string|int, T>` variants.

## Test plan

- [x] Install dev branch in a project: `composer require mll-lab/php-cs-fixer-config:dev-phpdoc-simplify-array-key-fixer --dev`
- [x] Run php-cs-fixer and verify it transforms `array<array-key, T>` to `array<T>`
- [x] Verify PHPStan still passes after the transformation

🤖 Generated with [Claude Code](https://claude.com/claude-code)